### PR TITLE
Use latest available template

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -606,7 +606,7 @@ class VmsModule(BaseModule):
                         self.param('template_version')
                     )
                 )
-            template = sorted(templates,key=lambda t: t.version.version_number)[-1]
+            template = sorted(templates, key=lambda t: t.version.version_number, reverse=True)[0]
 
         return template
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -606,7 +606,7 @@ class VmsModule(BaseModule):
                         self.param('template_version')
                     )
                 )
-            template = templates[0]
+            template = sorted(templates,key=lambda t: t.version.version_number)[-1]
 
         return template
 


### PR DESCRIPTION
##### SUMMARY
Documentation states:
template_version: version number of the template to be used for VM. By default the latest available version of the template is used.

This was not true because if parameter was not specified, template[0] is choosen, without checking if is the latest. Now, sorting + selecting the latest selects the one with the latest version number.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
cloud/ovirt/ovirt_vms module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
[root@vlpiansible001 ~]# ansible --version
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

```


##### ADDITIONAL INFORMATION
How to reproduce the wrong behavior of this module in oVirt:

1. create a new template
2. create a second template which is subversion of the previously created one, introducing some changes so you can distinguish between two templates.
3. try deploying a new vm with a playbook like this:
```
---
- name: Clonazione Template
  ovirt_vms:
    auth:
      username: user
      password: password
      url: http://engine/ovirt-engine/api/
      ca_file: "/etc/pki/ovirt-engine/ca.pem"
    name: "vm_name"
    template: "TemplateNAME"
    cluster: "cluster_name"
    clone: True
    high_availability: true
    timeout: 520
    nics:
    - name: nic1
      profile_name: "ovirtmgmt"
```

You can check that the vm gets deployed with the older template and not the newer one.
